### PR TITLE
Add configurable DPI input and fix DPI-based positioning for sprites/animations

### DIFF
--- a/GodotExport.as
+++ b/GodotExport.as
@@ -353,8 +353,8 @@
 			var currentRowHeight:int = 0;
 
 			var MAX_SAFE_ATLAS_SIZE:int = 4096;
-			var scaledAtlasWidth:int = Math.min(MAX_ATLAS_WIDTH * dpiScaleFactor, MAX_SAFE_ATLAS_SIZE);
-			var scaledAtlasHeight:int = Math.min(MAX_ATLAS_HEIGHT * dpiScaleFactor, MAX_SAFE_ATLAS_SIZE);
+			var scaledAtlasWidth:int = Math.min(MAX_ATLAS_WIDTH , MAX_SAFE_ATLAS_SIZE);
+			var scaledAtlasHeight:int = Math.min(MAX_ATLAS_HEIGHT , MAX_SAFE_ATLAS_SIZE);
 			var createNewAtlas = function():void {
 				atlases.push(new BitmapData(scaledAtlasWidth, scaledAtlasHeight, true, 0x00000000));
 				currentX = 0;


### PR DESCRIPTION
### Problem
Original exporter used a fixed 72 DPI (Dots Per Inch). No control over export resolution or scale, resulting in either too small or blurred textures.

### Solution
Added a configurable DPI system with exportDPI, baseDPI, and dpiScaleFactor.
All export operations (texture rendering, atlas packing, node transforms, animation tracks) now respect this factor.
72 DPI = Default DPI
300 DPI = High resolution DPI

### Summary of Changes
DPI Configuration:
Introduced exportDPI:Number, baseDPI:Number, dpiScaleFactor:Number.
Added UI field dpiInput and live handler onDPIChange.
Added API: setExportDPI(newDPI) and getExportDPI().

### Scaling Propagation:
Applied DPI scaling to:
Texture rendering: via Matrix.scale(dpiScaleFactor, dpiScaleFactor)
Atlas generation: adjusted atlas size and region rects
Node transforms: position × dpiScaleFactor
Animation tracks: position/scale × dpiScaleFactor

### UX:
DPI factor logged on start and on change

### Known Regression ⚠️
Issue: Sprite misplacement in atlas mode (atlasEnabled = true) at DPI ≠ 72.

